### PR TITLE
Feature: Culture Awareness

### DIFF
--- a/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.controller.js
+++ b/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.controller.js
@@ -224,6 +224,9 @@
                     if (Umbraco.Sys.ServerVariables.boev.enabledLockFunction || false) {
                         // delay the call for content locks on page load, because it can beat the component render
                         setTimeout(() => {
+                            // making sure everything is unlocked on the view before reassessing the locked state
+                            toggleViewInactive(false);
+
                             if (isCultureAware) {
                                 backOfficeEditorViewServices.getContentLocks($routeParams.id, $routeParams.cculture ?? $routeParams.mculture);
                             }

--- a/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.controller.js
+++ b/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.controller.js
@@ -11,6 +11,7 @@
     function backOfficeEditorViewMenuController($scope, $rootScope, eventsService, editorService, $routeParams, backOfficeEditorViewServices) {
         var injector = angular.element('#umbracoMainPageBody').injector();
         var authResource = injector.get('authResource');
+        var isCultureAware = Umbraco.Sys.ServerVariables.boev.isCultureAware === true;
 
         var vm = this;
         vm.openViewDrawer = openViewDrawer;
@@ -54,6 +55,11 @@
                         userEmail: user.email,
                         contentId: $routeParams.id
                     };
+
+                    if (isCultureAware) {
+                        lockData.culture = $routeParams.cculture ?? $routeParams.mculture;
+                    }
+
                     if (vm.isLocked) {
                         backOfficeEditorViewServices.addUserLock(lockData);
                     } else {
@@ -159,6 +165,7 @@
         var oldHref = document.location.href;
         var injector = angular.element('#umbracoMainPageBody').injector();
         var authResource = injector.get('authResource');
+        var isCultureAware = Umbraco.Sys.ServerVariables.boev.isCultureAware === true;
 
         // Initialise the services and trigger our functions when it's done
         backOfficeEditorViewServices.initialize().then(() => {
@@ -207,12 +214,22 @@
                             userName: user.name,
                             contentId: $routeParams.id
                         };
+
+                        if (isCultureAware) {
+                            viewData.culture = $routeParams.cculture ?? $routeParams.mculture;
+                        }
+
                         backOfficeEditorViewServices.registerView(viewData);
                     });
                     if (Umbraco.Sys.ServerVariables.boev.enabledLockFunction || false) {
                         // delay the call for content locks on page load, because it can beat the component render
                         setTimeout(() => {
-                            backOfficeEditorViewServices.getContentLocks($routeParams.id);
+                            if (isCultureAware) {
+                                backOfficeEditorViewServices.getContentLocks($routeParams.id, $routeParams.cculture ?? $routeParams.mculture);
+                            }
+                            else {
+                                backOfficeEditorViewServices.getContentLocks($routeParams.id);
+                            }
                         }, 500);
                     }
                 }
@@ -248,6 +265,11 @@
                                     userEmail: user.email,
                                     contentId: $routeParams.id
                                 };
+
+                                if (isCultureAware) {
+                                    lockData.culture = $routeParams.cculture ?? $routeParams.mculture;
+                                }
+
                                 backOfficeEditorViewServices.removeUserLock(lockData);
                             });
                         }
@@ -283,6 +305,11 @@
                         userEmail: user.email,
                         contentId: $routeParams.id
                     };
+
+                    if (isCultureAware) {
+                        lockData.culture = $routeParams.cculture ?? $routeParams.mculture;
+                    }
+
                     backOfficeEditorViewServices.removeUserLock(lockData);
                 });
             }
@@ -293,7 +320,13 @@
         function lockedContentChangeReceived(eventData) {
             var messages = eventData.data;
             var matchingContent = messages.filter((item) => {
-                return item.contentId == parseInt($routeParams.id);
+                var isMatch = item.contentId === parseInt($routeParams.id);
+
+                if (isCultureAware) {
+                    isMatch = isMatch && item.culture === ($routeParams.cculture ?? $routeParams.mculture);
+                }
+
+                return isMatch;
             });
 
             if (typeof (matchingContent) == 'undefined') {
@@ -322,14 +355,20 @@
 
         function toggleViewInactive(shouldLock) {
             setTimeout(() => {
-                if (document.querySelector('[data-element="editor-container"]'))
-                    document.querySelector('[data-element="editor-container"]').style.pointerEvents = shouldLock ? "none" : "auto";
-                if (document.querySelector('[data-element="editor-footer"]'))
-                    document.querySelector('[data-element="editor-footer"]').style.pointerEvents = shouldLock ? "none" : "auto";
-                if (document.querySelector('#nameField'))
-                    document.querySelector('#nameField').style.pointerEvents = shouldLock ? "none" : "auto";
-                if (document.querySelector('[data-element="editor-actions"]'))
-                    document.querySelector('[data-element="editor-actions"]').style.pointerEvents = shouldLock ? "none" : "auto";
+                const elementsToToggle = [
+                    '[data-element="editor-container"]',
+                    '[data-element="editor-footer"]',
+                    'ng-form[name="headerNameForm"]',
+                    '[data-element="editor-actions"]'
+                ];
+
+                elementsToToggle.forEach(selector => {
+                    document.querySelectorAll(selector).forEach(element => {
+                        if (element) {
+                            element.style.pointerEvents = shouldLock ? "none" : "auto";
+                        }
+                    });
+                });
             }, 1000);
         }
 
@@ -337,7 +376,13 @@
             var messages = eventData.data;
             // Look for any content that matches what we're looking at (but isn't us)
             var matchingContent = messages.filter((item) => {
-                return item.sessionId != window.boevSessionId && item.contentId == parseInt($routeParams.id)
+                var isMatch = item.sessionId !== window.boevSessionId && item.contentId === parseInt($routeParams.id);
+
+                if (isCultureAware) {
+                    isMatch = isMatch && item.culture === ($routeParams.cculture ?? $routeParams.mculture);
+                }
+
+                return isMatch;
             });
 
             if (typeof (matchingContent) == 'undefined') {

--- a/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.services.js
+++ b/BackOfficeEditorView.Assets/App_Plugins/BackOfficeEditorView/scripts/BackOfficeEditorView.services.js
@@ -84,8 +84,8 @@
         $.connection.send('removeViews', sessionId);
     }
 
-    var getContentLocks = function (contentId) {
-        $.connection.send('GetContentLocksForContentId', contentId);
+    var getContentLocks = function (contentId, culture = '') {
+        $.connection.send('GetContentLocksForContentId', contentId, culture);
     }
 
     var addUserLock = function (lockData) {

--- a/BackOfficeEditorView.Core/Configuration/BackOfficeEditorViewSettings.cs
+++ b/BackOfficeEditorView.Core/Configuration/BackOfficeEditorViewSettings.cs
@@ -13,5 +13,6 @@ namespace BackOfficeEditorView.Core.Configuration
     {
         public string Name { get; set; }
         public bool CanLockContent { get; set; }
+        public bool IsCultureAware { get; set; }
     }
 }

--- a/BackOfficeEditorView.Core/Hubs/SyncHub.cs
+++ b/BackOfficeEditorView.Core/Hubs/SyncHub.cs
@@ -100,7 +100,7 @@ namespace BackOfficeEditorView.Core.Hubs
             if (!int.TryParse(contentIdStr?.ToString(), out var contentId))
                 return;
 
-            var cultureStr = !string.IsNullOrEmpty(culture.ToString()) ? culture.ToString() : null;
+            var cultureStr = culture?.ToString();
 
             var contentLocks = _contentLockManager.GetCurrentContentLocks(contentId, cultureStr);
             

--- a/BackOfficeEditorView.Core/Models/UserContentLock.cs
+++ b/BackOfficeEditorView.Core/Models/UserContentLock.cs
@@ -16,5 +16,7 @@ namespace BackOfficeEditorView.Core.Models
         public string? UserEmail { get; set; }
         [JsonProperty("contentId")]
         public int? ContentId { get; set; }
+        [JsonProperty("culture")]
+        public string? Culture { get; set; }
     }
 }

--- a/BackOfficeEditorView.Core/Models/UserContentView.cs
+++ b/BackOfficeEditorView.Core/Models/UserContentView.cs
@@ -1,9 +1,4 @@
 ﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace BackOfficeEditorView.Core.Models
 {
@@ -19,5 +14,7 @@ namespace BackOfficeEditorView.Core.Models
         public string UserName { get; set; }
         [JsonProperty("contentId")]
         public int ContentId { get; set; }
+        [JsonProperty("culture")]
+        public string? Culture { get; set; }
     }
 }

--- a/BackOfficeEditorView.Core/Notifications/BackOfficeEditorViewServerVariablesHandler.cs
+++ b/BackOfficeEditorView.Core/Notifications/BackOfficeEditorViewServerVariablesHandler.cs
@@ -43,8 +43,9 @@ namespace BackOfficeEditorView.Core.Notifications
         {
             notification.ServerVariables.Add("boev", new Dictionary<string, object>
             {
-                {"signalRHub",  _hubRoutes.GetBackOfficeEditorViewHubRoute() },
-                {"enabledLockFunction", _settings.Value?.CanLockContent ?? false }
+                { "signalRHub", _hubRoutes.GetBackOfficeEditorViewHubRoute() },
+                { "enabledLockFunction", _settings.Value?.CanLockContent ?? false },
+                { "isCultureAware", _settings.Value?.IsCultureAware ?? false }
             });
         }
 
@@ -54,7 +55,5 @@ namespace BackOfficeEditorView.Core.Notifications
             if (user == null) return false;
             return user.Groups.Any(x => x.Alias.Equals(Constants.Security.AdminGroupAlias));
         }
-
     }
-
 }

--- a/BackOfficeEditorView.Core/Services/IContentLockManager.cs
+++ b/BackOfficeEditorView.Core/Services/IContentLockManager.cs
@@ -6,6 +6,6 @@ namespace BackOfficeEditorView.Core.Services
     {
         List<UserContentLock> AddUserLock(UserContentLock ucLock);
         List<UserContentLock> RemoveUserLocks(int userId);
-        List<UserContentLock> GetCurrentContentLocks(int? contentId = null);
+        List<UserContentLock> GetCurrentContentLocks(int? contentId = null, string? culture = null);
     }
 }

--- a/BackOfficeEditorView.Core/Services/IViewManager.cs
+++ b/BackOfficeEditorView.Core/Services/IViewManager.cs
@@ -13,7 +13,7 @@ namespace BackOfficeEditorView.Core.Services
         void RemoveByUser(int userId);
         void RemoveBySession(string sessionId);
         List<UserContentView> FetchAllViews();
-        List<UserContentView> FetchCurrentViews(int contentId);
+        List<UserContentView> FetchCurrentViews(int contentId, string? culture = null);
 
     }
 }


### PR DESCRIPTION
Related issue: [issues/5](https://github.com/Rockerby/Umbraco.BackOfficeEditorView/issues/5)

Added functionality to check the culture of the currently opened page. With this the view and lock functionalities now work only when the users are editing the same language variant of the given page.
![image](https://github.com/Rockerby/Umbraco.BackOfficeEditorView/assets/71294989/c6b072ae-4f41-46dc-9919-747d2f37b9c9)

To enable it, a new flag has to be added to the appsettings.json:
```
"BackOfficeEditorView": {
    "canLockContent": true,
    "isCultureAware": true
  }
```